### PR TITLE
Includes no-referrer header 

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,7 +5,10 @@
 
   <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
-
+  
+  <!-- Referrer header which disables clients sending tracking info to sites linked from CYD -->
+  <meta name="referrer" content="no-referrer">
+  
   <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
   <link rel="alternate" type="application/atom+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" />


### PR DESCRIPTION
This header disables some tracking of users directed from cyd to another site since it tells browsers not to include cyd.liu.se as origin to the next site. 

This header is rather new, so specification is not ready yet and I couldn't find an nginx add_header for it. Added it to CYDs webpage but in the future we should enable this in nginx for all sites. 

This is in order to better comply with webkoll.dataskydd.net, sponsered by IIS and Internetfonden. 
